### PR TITLE
Correction bug 6NB8

### DIFF
--- a/library/N2/2N12.json
+++ b/library/N2/2N12.json
@@ -7,12 +7,12 @@
     "options":[{
         "name":"Equations de la forme $$|x|=b$$",
         "vars":{"b":"1_20"},
-        "question": "|x| = ${:b}",
+        "question": "\\text{Résoudre dans } \\mathbb{R} : |x| = ${:b}",
         "answer":"\\text{solutions : } \\color{red}{-${:b} \\text{ et } ${:b}}"
     },{
         "name":"Equations de la forme $$|x|=b$$ avec b entier relatif",
         "vars":{"b":"-5_20_^0,}"},
-        "question": "|x| = ${:b}",
+        "question": "\\text{Résoudre dans } \\mathbb{R} : |x| = ${:b}",
         "answer":"${ :b>0 ? -:b +'\\text{ et }'+ :b : '\\text{Pas de solution}' }"
     },{
         "name":"Equations de la forme $$|x-a|=b$$",
@@ -22,7 +22,7 @@
             "rep1" : "${ Number(:a) + Number(:b) }",
             "rep2" : "${ Number(:a) - Number(:b)}"
         },
-        "question": "${ :a>0 ? '|x-'+:a+'|='+:b : '|x+'+(-:a)+'|='+:b   }  ",
+        "question": "\\text{Résoudre dans } \\mathbb{R} :  ${:a>0 ? '|x-'+:a+'|='+:b : '|x+'+(-:a)+'|='+:b   }  ",
         "answer":"${ :rep1 + '\\text{ et }'+ :rep2   }"
     }
     ]

--- a/library/N2/2N12.json
+++ b/library/N2/2N12.json
@@ -1,0 +1,29 @@
+{
+    "title":"Equation avec une valeur absolue",
+    "type":"latex",
+    "ID":"2N12",
+    "description":"Résoudre les équations de la forme $$|x-a|=b$$",
+    "dest":["2N1"],
+    "options":[{
+        "name":"Equations de la forme $$|x|=b$$",
+        "vars":{"b":"1_20"},
+        "question": "|x| = ${:b}",
+        "answer":"\\text{solutions : } \\color{red}{-${:b} \\text{ et } ${:b}}"
+    },{
+        "name":"Equations de la forme $$|x|=b$$ avec b entier relatif",
+        "vars":{"b":"-5_20_^0,}"},
+        "question": "|x| = ${:b}",
+        "answer":"${ :b>0 ? -:b +'\\text{ et }'+ :b : '\\text{Pas de solution}' }"
+    },{
+        "name":"Equations de la forme $$|x-a|=b$$",
+        "vars":{
+            "b":"1_20",
+            "a":"-4_4_^0",
+            "rep1" : "${ Number(:a) + Number(:b) }",
+            "rep2" : "${ Number(:a) - Number(:b)}"
+        },
+        "question": "${ :a>0 ? '|x-'+:a+'|='+:b : '|x+'+(-:a)+'|='+:b   }  ",
+        "answer":"${ :rep1 + '\\text{ et }'+ :rep2   }"
+    }
+    ]
+}

--- a/library/N6/6NB8.json
+++ b/library/N6/6NB8.json
@@ -24,6 +24,6 @@
     "audio":"La fraction ${:num} ${math.NumberToFraction(:den)} est-elle égale à ${:num2} ${math.NumberToFraction(:den*:coeff)} ?",
     "question":"\\text{Les fractions }\\dfrac{${:num}}{${:den}}\\text{ et }\\dfrac{${:num2}}{${:den2}}\\text{ sont-elles égales ?}",
     "shortq":"\\dfrac{${:num}}{${:den}}\\stackrel{!}{=}\\dfrac{${:num2}}{${:den2}}",
-    "answer":"\\dfrac{${:num}}{${:den}} ~ \\color{red}{${:choix==0?'=':'\\not ='}}~ \\dfrac{${:num*:coeff}}{${:den*:coeff}}",
+    "answer":"\\dfrac{${:num}}{${:den}} ~ \\color{red}{${:choix==0?'=':'\\not ='}}~ \\dfrac{${:num2}}{${:den2}}",
     "value":["${:r}","${:rl}"]
 }


### PR DESCRIPTION
Correction bug 6NB8 : 
Dans la correction, lorsque les fraction sont différentes, la correction affiche une fraction égale.
Mais avec un symbole différent.
Par exemple 
$5/​4 \neq  46/36$​